### PR TITLE
Replace des and md4 usage with pure javascript versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "axios": "^1.2.0",
+    "des.js": "^1.0.1",
     "dev-null": "^0.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "axios": "^1.2.0",
     "des.js": "^1.0.1",
-    "dev-null": "^0.1.1"
+    "dev-null": "^0.1.1",
+    "js-md4": "^0.3.2"
   }
 }

--- a/src/hash.js
+++ b/src/hash.js
@@ -3,6 +3,7 @@
 // Original source at https://github.com/elasticio/node-ntlm-client/blob/master/lib/hash.js
 
 const crypto = require('crypto');
+const desjs = require('des.js');
 
 function createLMResponse(challenge, lmhash) {
 	let buf = new Buffer.alloc(24),
@@ -58,7 +59,7 @@ function calculateDES(key, message) {
 		desKey[i] |= (parity % 2) === 0 ? 1 : 0;
 	}
 
-	let des = crypto.createCipheriv('DES-ECB', desKey, '');
+	const des = des.DES.create({type: 'encrypt', ley: desKey});
 	return des.update(message);
 }
 

--- a/src/hash.js
+++ b/src/hash.js
@@ -4,6 +4,7 @@
 
 const crypto = require('crypto');
 const desjs = require('des.js');
+const md4 = require('js-md4');
 
 function createLMResponse(challenge, lmhash) {
 	let buf = new Buffer.alloc(24),
@@ -77,9 +78,9 @@ function createNTLMResponse(challenge, ntlmhash) {
 }
 
 function createNTLMHash(password) {
-	let md4sum = crypto.createHash('md4');
+	let md4sum = md4.create();
 	md4sum.update(new Buffer.from(password, 'ucs2'));
-	return md4sum.digest();
+	return md4sum.buffer();
 }
 
 function createNTLMv2Hash(ntlmhash, username, authTargetName) {


### PR DESCRIPTION
If an OpenSSL3-based nodejs isn't started with --openssl-legacy-provider it will refuse to enable DES-ECB and md4 algorithms, see https://github.com/Catbuttes/axios-ntlm/issues/19 

This PR replaces both algorithms with pure JS implementations.

I figure there may be some subtle safety issues (eg side channels) when using a JS-based implementation instead of OpenSSL, but the algorithms involved shouldn't be used at all anyway if you're concerned about security. (And neither should NTLM itself)